### PR TITLE
fix(search): recover the warm camofox tab when a reused tab times out

### DIFF
--- a/crates/crw-search/src/camofox_search.rs
+++ b/crates/crw-search/src/camofox_search.rs
@@ -18,7 +18,8 @@
 //! access and guards ONE long-lived warm tab that is reused across queries and
 //! never deleted — the context never sees concurrent tabs nor drops to zero.
 //! If the warm tab goes stale (idle eviction / camofox restart) the next
-//! navigate fails and we transparently recreate the tab and retry once.
+//! navigate fails — or hangs, when camofox accepts a navigate for a tab it no
+//! longer has — and we transparently recreate the tab and retry once.
 //!
 //! Rows are mapped into the existing [`SearxngResponse`] shape so the entire
 //! downstream transform / rerank pipeline (`transform.rs`, `rerank.rs`) is
@@ -291,9 +292,26 @@ impl CamofoxSearchClient {
             let outcome = if matches!(engine, SearchEngine::Github) {
                 self.github_search(&params.q).await
             } else {
+                // Whether this attempt will reuse a cached id rather than mint a
+                // fresh tab. Captured before the attempt because `ensure_tab`
+                // populates `tab` as a side effect.
+                let reused_tab = tab.is_some();
                 match self.attempt(&mut tab, engine, params).await {
                     Ok(rows) => Ok(rows),
-                    Err(e) if is_stale_tab(&e) => {
+                    // A timeout on a *reused* tab is the dead-tab signature, not
+                    // a slow page: camofox does not 404 a navigate for a tab it
+                    // no longer has, it accepts the request and hangs until its
+                    // own (longer) navigate timeout, so we only ever see our
+                    // client timeout. Without this the cached id is never
+                    // dropped and every later search repeats the same stall —
+                    // the endpoint stays broken until the process restarts.
+                    // A fresh tab that times out really is a slow page, and is
+                    // reported as-is: `reused_tab` is false on the retry below,
+                    // so this can recurse at most once.
+                    Err(e)
+                        if is_stale_tab(&e)
+                            || (reused_tab && matches!(e, SearchError::Timeout)) =>
+                    {
                         // Warm tab/context died (idle eviction or camofox
                         // restart). Drop the dead id, let any in-flight relaunch
                         // settle, then recreate and retry this engine once.
@@ -556,8 +574,13 @@ fn merge_results(
 /// Whether an error means the warm tab/context is gone and recreating it could
 /// recover — a missing tab (404), a server-side fault like the upstream
 /// `window is null` (5xx), or a dropped connection during a relaunch. A
-/// timeout or a malformed-response parse error won't be helped by recreating,
-/// so they're reported as-is.
+/// malformed-response parse error won't be helped by recreating, so it is
+/// reported as-is.
+///
+/// Timeouts are deliberately *not* classified here, because the same error
+/// means different things depending on the tab: on a freshly minted tab it is a
+/// slow page, on a reused one it is the dead-tab signature. `fetch` applies
+/// that context-dependent rule at the call site.
 fn is_stale_tab(e: &SearchError) -> bool {
     match e {
         SearchError::Upstream { status, .. } => *status == 404 || *status >= 500,
@@ -790,5 +813,86 @@ mod github_api_tests {
             ..Default::default()
         };
         assert!(client.fetch(&params).await.is_err());
+    }
+
+    /// A timeout on a *reused* warm tab is the dead-tab signature (camofox
+    /// accepts a navigate for a tab it no longer has and hangs instead of
+    /// returning 404), so the cached id is dropped and the search retried on a
+    /// fresh tab. Regression guard: without it the client keeps addressing the
+    /// dead tab and every later search stalls identically, leaving the endpoint
+    /// broken until the process restarts.
+    #[tokio::test]
+    async fn timeout_on_reused_tab_recreates_it_and_recovers() {
+        let server = MockServer::start().await;
+        let rows = r#"[{"url":"https://rust-lang.org","title":"Rust","content":"lang"}]"#;
+
+        // `t1` is minted first and later "dies"; `t2` is its replacement.
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "tabId": "t1" })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "tabId": "t2" })))
+            .mount(&server)
+            .await;
+
+        // t1 answers the first navigate (warming the cache), then hangs well
+        // past the client timeout on every later one.
+        Mock::given(method("POST"))
+            .and(path("/tabs/t1/navigate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ok": true })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tabs/t1/navigate"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(30)))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tabs/t2/navigate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ok": true })))
+            .mount(&server)
+            .await;
+
+        for tab in ["t1", "t2"] {
+            Mock::given(method("POST"))
+                .and(path(format!("/tabs/{tab}/wait")))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ok": true })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path(format!("/tabs/{tab}/evaluate")))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "result": rows })))
+                .mount(&server)
+                .await;
+        }
+
+        let client = CamofoxSearchClient::new(server.uri(), None, None, Duration::from_millis(300));
+        let params = SearxngParams {
+            q: "rust".to_string(),
+            camofox_engines: vec![SearchEngine::Google],
+            ..Default::default()
+        };
+
+        // First search warms the cache with t1.
+        let first = client.fetch(&params).await.expect("first search succeeds");
+        assert_eq!(first.results.len(), 1);
+
+        // Second search stalls on the now-dead t1, recreates as t2, and still
+        // returns results — transparently, with no engine reported unresponsive.
+        let second = client
+            .fetch(&params)
+            .await
+            .expect("stale-tab timeout recovers on a fresh tab");
+        assert_eq!(second.results.len(), 1);
+        assert!(
+            second.unresponsive_engines.is_empty(),
+            "recovery should be transparent, got {:?}",
+            second.unresponsive_engines
+        );
     }
 }


### PR DESCRIPTION
## Symptom

`/v1/search` starts returning `504 {"error":"Timeout after 15000ms"}` for **every** request and never recovers. Scraping stays healthy, camofox stays healthy — only search is wedged, and only a `crw` restart clears it.

## Root cause

`CamofoxSearchClient` keeps one long-lived warm tab. When that tab disappears (idle eviction / camofox restart), `fetch` is supposed to notice and recreate it — `is_stale_tab` covers 404, 5xx and transport errors.

It does not cover the case that actually happens: **camofox does not 404 a navigate for a tab it no longer has.** It accepts the request and hangs until its own navigate timeout (30s), which is longer than the search client's `[search].timeout_ms`. So the client only ever observes `SearchError::Timeout`, which `is_stale_tab` deliberately excludes:

```rust
SearchError::Timeout | SearchError::InvalidResponse(_) => false,
```

The dead id is never dropped from the cache, so every later search addresses the same dead tab and stalls identically.

## Evidence

Observed on a deployment where the camofox container restarted while `crw` stayed up (camofox up 4h, crw up 26h):

- `GET /tabs` on camofox → `{"running":true,"tabs":[]}` — the cached tab genuinely did not exist
- camofox logged, for the cached id, on every request:
  `navigate failed  tabId=ef79d653-…  error="navigate timed out after 30000ms"`
- 4/4 searches returned 504 after exactly 15.0s
- a **freshly created** tab served the same query fine — `@google_search` in 8.6s cold, 4.4–6.8s warm, 162 links in the SERP
- `/v1/scrape` was unaffected throughout, because the render path creates and deletes a tab per request; only search holds one across requests

## Fix

Treat a timeout as a stale-tab signal when — and only when — the attempt reused a cached id. A timeout on a freshly minted tab really is a slow page and is still reported as-is. The retry always runs on a fresh tab, so `reused_tab` is false there and the recovery cannot recurse.

`is_stale_tab` is left alone: the classification is genuinely context-dependent, so the rule lives at the call site where the context exists. Its doc comment is updated to say so rather than contradict the code.

## Test

`timeout_on_reused_tab_recreates_it_and_recovers` — wiremock server whose first navigate on `t1` succeeds (warming the cache) and whose later ones hang past the client timeout. Asserts the second `fetch` recovers on a fresh `t2` and reports no unresponsive engine.

Confirmed to fail without the change (`stale-tab timeout recovers on a fresh tab: Timeout`) and pass with it. Full `crw-search` suite: 75 passed. `cargo fmt` clean, `cargo clippy --all-targets` silent.

## Scope note

Deployed and running. Worth flagging honestly: I could not reproduce the 30s *hang* on demand — restarting the camofox container produces an orphaned tab that camofox rejects quickly (~1.8s), which the existing `is_stale_tab` path already handles. The hang appears to need whatever state that longer-lived instance was in. The production evidence above is what the fix is built on, and the unit test pins the behaviour.

One consequence worth weighing: on the hang path the recovering request now costs a full client timeout plus the retry (~15s + 0.75s backoff + a fresh fetch) before returning, so a caller with a tight deadline may still see that first request fail. It will be the last one to fail, rather than the first of an unbounded run.